### PR TITLE
fixed the ruby_engine version.rb constant issue. Use a clean bundle e…

### DIFF
--- a/capsulecd.gemspec
+++ b/capsulecd.gemspec
@@ -1,9 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-load 'lib/capsulecd/version.rb' #using load here instead of require because of issues when dogfooding CapsuleCD.
-# The Gem::Specification::load() function that loads the gemspec in the RubyEngine detects that CapsuleCD version.rb is already
-# required, so it will ignore subsequent load commands. This problem only occurs in CapsuleCD, not any other Gem
+require 'capsulecd/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'capsulecd'

--- a/capsulecd.gemspec
+++ b/capsulecd.gemspec
@@ -1,7 +1,9 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'capsulecd/version'
+load 'lib/capsulecd/version.rb' #using load here instead of require because of issues when dogfooding CapsuleCD.
+# The Gem::Specification::load() function that loads the gemspec in the RubyEngine detects that CapsuleCD version.rb is already
+# required, so it will ignore subsequent load commands. This problem only occurs in CapsuleCD, not any other Gem
 
 Gem::Specification.new do |spec|
   spec.name          = 'capsulecd'

--- a/lib/capsulecd/ruby/ruby_helper.rb
+++ b/lib/capsulecd/ruby/ruby_helper.rb
@@ -52,8 +52,11 @@ module CapsuleCD
       end
 
       def self.load_gemspec_data(gemspec_path)
-        gemspec_data = self.execute_in_child do
-          Gem::Specification::load(gemspec_path)
+        gemspec_data = nil
+        Bundler.with_clean_env do
+          gemspec_data = self.execute_in_child do
+            Gem::Specification::load(gemspec_path)
+          end
         end
         if !gemspec_data
           fail CapsuleCD::Error::BuildPackageInvalid, '*.gemspec could not be parsed.'


### PR DESCRIPTION
…nv and the constant wont be loaded for the gem build command.